### PR TITLE
Add option to pass an undefiend context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -191,9 +191,13 @@ export function parse(yamlContent: string): [object, YAMLContext] {
  */
 export function stringify(
     updatedYaml: object,
-    context: YAMLContext,
+    context: YAMLContext | undefined,
     options?: yaml.ToStringOptions
 ): string {
+    if (!context) {
+        return yaml.stringify(updatedYaml, options);
+    }
+
     const document = context.document;
 
     shapeshiftDocument(document.toJSON(), updatedYaml, document);

--- a/tests/undefinedContext.test.ts
+++ b/tests/undefinedContext.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "vitest";
+import { stringify } from "../src/index.js";
+
+describe("yaml-transmute", () => {
+    test("handles undefiend context", () => {
+        const undefinedDoc = stringify({ foo: "bar" }, undefined).trim();
+
+        expect(undefinedDoc).toBe(`foo: bar`);
+    });
+});


### PR DESCRIPTION
This fallbacks to using the original yaml stringify function